### PR TITLE
Pin the dependences' versions

### DIFF
--- a/qualitymetrics_config.xml
+++ b/qualitymetrics_config.xml
@@ -2,8 +2,8 @@
   <description>Metrics and graphics to check the quality of the data</description>
 
   <requirements>
-    <requirement type="package">r-batch</requirement>
-    <requirement type="package">bioconductor-ropls</requirement>
+    <requirement type="package" version="1.1_4">r-batch</requirement>
+    <requirement type="package" version="1.10.0">bioconductor-ropls</requirement>
   </requirements>
   
   <stdio>


### PR DESCRIPTION
Otherwise, Conda will always take the laster one.